### PR TITLE
Running MySQL in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__
 *.txt
 .vscode
-config.py
+db_config.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+
+services:
+  db:
+    image: mysql
+    environment:
+      MYSQL_DATABASE: 'booking'
+      MYSQL_USER: 'admin'
+      MYSQL_PASSWORD: 'do-not-use-in-production'
+      MYSQL_ROOT_PASSWORD: 'do-not-use-in-production'
+    ports:
+      - 3306:3306
+    expose:
+      - 3306

--- a/setup_db.py
+++ b/setup_db.py
@@ -1,0 +1,43 @@
+import pymysql
+from student import dconfig
+
+def _create_conn():
+    return pymysql.connect(
+        host=dconfig.DB_Server,
+        user=dconfig.DB_Username,
+        password=dconfig.DB_Password,
+        db=dconfig.DB_Name
+    )
+
+def create_user_table():
+    conn = _create_conn()
+
+    create_sql = '''CREATE TABLE users (
+        id INT NOT NULL AUTO_INCREMENT,
+        email VARCHAR(64),
+        name VARCHAR(64),
+        PRIMARY KEY (id)
+    )'''
+
+    insert_sql = 'INSERT INTO `users` (`email`, `name`) VALUES (%s, %s)'
+
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(create_sql, ())
+            cursor.execute(insert_sql, ('mike@tyson.com', 'Mike'))
+        conn.commit()
+    finally:
+        conn.close()
+
+def drop_user_table():
+    conn = _create_conn()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute('DROP TABLE users', ())
+        conn.commit()
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    drop_user_table()
+    create_user_table()

--- a/student/dconfig.py
+++ b/student/dconfig.py
@@ -1,0 +1,4 @@
+DB_Server = 'localhost'
+DB_Name = 'booking'
+DB_Username = 'admin'
+DB_Password = 'do-not-use-in-production'

--- a/student/dconfig.py
+++ b/student/dconfig.py
@@ -1,4 +1,0 @@
-DB_Server = 'localhost'
-DB_Name = 'booking'
-DB_Username = 'admin'
-DB_Password = 'do-not-use-in-production'


### PR DESCRIPTION
Denna PR visar hur man kan köra MySQL i docker och ansluta till denna med hjälp av [pymysql](https://github.com/PyMySQL/PyMySQL).

I terminalen, kör `docker-compose up` för att starta igång databasen. Tips är att göra detta i ett separat terminalfönster eftersom docker-compose kommer "sno" terminalfönstret. Alternativt kör `docker-compose up -d` för att köra i detached mode.

Kör `docker-compose down` för att riva ner och ta bort databasen.

`setup_db.py` är ett script som kan användas för att skapa/reset:a databasen av oss utvecklare. Om man lägger in databas-strukturen där så blir det lätt att återskapa en fräsch korrekt uppsatt databas för alla lokalt på sina maskiner.
