### PR TITLE
Add custom nginx configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,64 @@
+user  nginx;
+worker_processes 2;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+events {
+    worker_connections 2048;
+}
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log  /var/log/nginx/access.log  main;
+    sendfile        on;
+    keepalive_timeout  300;
+
+    server_tokens off;
+
+    # redirect HTTP to HTTPS, always
+    server {
+        listen 80;
+        server_name ${FQDN};
+        return 301 https://$server_name$request_uri;
+    }
+
+    server {
+        listen 443;
+
+        # SSL configuration
+        ssl_certificate /etc/letsencrypt/live/${FQDN}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/${FQDN}/privkey.pem;
+        ssl_session_cache shared:SSL:10m;
+        ssl_protocols TLSv1.2;
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+        ssl_prefer_server_ciphers on;
+        
+        # HSTS disabled for now
+        # add_header Strict-Transport-Security "max-age=31536000;" always;
+
+        # Security headers
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
+        add_header X-Robots-Tag none;
+        add_header Content-Security-Policy "frame-ancestors 'self'";
+        add_header X-Frame-Options DENY;
+        add_header Referrer-Policy same-origin;
+
+        location / {
+            try_files $uri @app;
+            proxy_set_header  X-Real-IP $remote_addr;
+        }
+
+        location @app {
+            include uwsgi_params;
+            uwsgi_pass unix:///tmp/uwsgi.sock;
+        }
+
+        location $USE_STATIC_URL {
+            alias $USE_STATIC_PATH;
+        }
+    }
+}
+daemon off;

--- a/prod.yml
+++ b/prod.yml
@@ -11,8 +11,12 @@ services:
       MYSQL_HOST: 'mysql'
       MYSQL_PASSWORD: '${MYSQL_PASSWORD}'
       REDIS_HOST: 'redis'
+      FQDN: '${FQDN}'
     depends_on:
       - mysql
       - redis
     ports:
       - 80:80
+      - 443:443
+    volumes:
+      - /etc/letsencrypt/live:/etc/letsencrypt/live


### PR DESCRIPTION
Requires a valid Let's Encrypt certificate to already exist on the host at `/etc/letsencrypt/live`. Also uses an environment variable named `FQDN`, should be the domain nginx listens too (hopefully definable from Travis?).

I am unable to test this properly. @einarpersson can you test this and see if it works?
 
Fixes #23 
Fixes #24 
