### PR TITLE
Rewrite HTTP headers in nginx configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses the [semantic versioning convention](https://semver.org/). Make sure to include all changes in releases within this file (and references to pull requests/issues where applicable).
 
+## next-release
+
+### Enhancments
+
+* Rewrite `Set-Cookie` HTTP header within nginx using `map`, adds the `SameSite=Strict` flag to the default Flask header.
+
 ## v0.1.1 (released 2019-12-20)
 
 ### Features

--- a/main.py
+++ b/main.py
@@ -86,6 +86,7 @@ def error_500(e):
 SESSION_TYPE = "redis"
 SESSION_REDIS = redis.Redis(host=environ.get("REDIS_HOST", "localhost"), db=0)
 
+SESSION_COOKIE_SECURE = True
 SESSION_PERMANENT = True
 PERMANENT_SESSION_LIFETIME = timedelta(hours=24)
 

--- a/nginx-http.conf
+++ b/nginx-http.conf
@@ -22,33 +22,8 @@ http {
 
     server_tokens off;
 
-    # redirect HTTP to HTTPS, always
     server {
         listen 80;
-        server_name booking.tullingelabs.se;
-        return 301 https://$server_name$request_uri;
-    }
-
-    server {
-        listen 443 ssl;
-
-        # SSL configuration
-        ssl_certificate /etc/letsencrypt/live/booking.tullingelabs.se/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/booking.tullingelabs.se/privkey.pem;
-        
-        ssl_session_cache shared:SSL:10m;
-        ssl_session_timeout 1440m;
-        ssl_session_tickets off;
-        ssl_prefer_server_ciphers off;
-
-        # Ciphers, from https://github.com/certbot/certbot/blob/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf
-        ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA";
-
-        # Protocols
-        ssl_protocols TLSv1.2 TLSv1.3;
-
-        # HSTS
-        add_header Strict-Transport-Security "max-age=31536000;" always;
 
         # Security headers
         add_header X-Content-Type-Options nosniff;
@@ -57,7 +32,7 @@ http {
         add_header Content-Security-Policy "frame-ancestors 'self'";
         add_header X-Frame-Options DENY;
         add_header Referrer-Policy same-origin;
-
+        
         location / {
             try_files $uri @app;
             proxy_set_header  X-Real-IP $remote_addr;
@@ -73,9 +48,9 @@ http {
         }
 
         # Rewrite Set-Cookie header
-        proxy_hide_header Set-Cookie;
+        uwsgi_hide_header Set-Cookie;
         add_header Set-Cookie $new_cookie;
-        
+
     }
 }
 daemon off;

--- a/nginx.conf
+++ b/nginx.conf
@@ -54,7 +54,8 @@ http {
         add_header Referrer-Policy same-origin;
 
         # Fix cookie origin error
-        add_header Set-Cookie "HttpOnly;Secure;SameSite=Strict";
+        # add_header Set-Cookie "HttpOnly;Secure;SameSite=Strict";
+        # set within Flask SESSION_COOKIE_SECURE instead
 
         location / {
             try_files $uri @app;


### PR DESCRIPTION
The default `Set-Cookie` header in Flask is not really secure. I've added the `SESSION_COOKIE_SECURE` variable within Flask (which makes sure the cookies are only present over HTTPS connections, client-side) but I also want to limit the cookie to a specific domain name (prevents cross-site requests, to some extent).

There is an option to do this within Flask, but I don't think it's compatible with the [Flask-Session](https://pythonhosted.org/Flask-Session/) module we're using.

So I've configured Nginx to rewrite the HTTP header from the UWSGI response before the request is then finally sent to the user. I also made a copy of the default `nginx.conf` with HTTP only (only for testing, I used it to test the header rewrite). The rewrite basically just add `SameSite=Strict` to the `Set-Cookie` header from UWSGI.

The only backside of this is that it also applies to static content. So requesting the `/static/css/style.css` stylesheet also returns the `Set-Cookie` header but with only `SameSite=Strict` (so it isn't actually setting any cookies).

Let me know if it works.